### PR TITLE
added unit tests for validation middleware

### DIFF
--- a/src/test/unit/middlewares/validation.spec.js
+++ b/src/test/unit/middlewares/validation.spec.js
@@ -47,22 +47,16 @@ describe('Validation middleware', () => {
   it('Should return error when body is not present', () => {
     req.body = null
 
-    try {
-      validationMiddleware({})(req, res, next)
-    } catch (err) {
-      expect(err).toEqual(1)
-    }
+    expect(() => validationMiddleware(mockSchema)(req, res, next)).toThrow(new Error(1))
   })
 
   it('Should return error when required field is not present', () => {
     validateRequired.mockImplementation(() => {
       throw 2
     })
-    try {
-      validationMiddleware(mockSchema)(req, res, next)
-    } catch (err) {
-      expect(err).toEqual(2)
-    }
+
+    expect(() => validationMiddleware(mockSchema)(req, res, next)).toThrow(new Error(2))
+
     expect(validateRequired).toHaveBeenCalledWith('test1', mockSchema.test1.required, undefined)
   })
 
@@ -93,11 +87,7 @@ describe('Validation middleware', () => {
       throw 3
     })
 
-    try {
-      validationMiddleware(mockSchema)(req, res, next)
-    } catch (err) {
-      expect(err).toEqual(3)
-    }
+    expect(() => validationMiddleware(mockSchema)(req, res, next)).toThrow(new Error(3))
 
     expect(validateFunc.type).toHaveBeenCalledWith('test1', mockSchema.test1.type, req.body.test1)
   })
@@ -111,11 +101,7 @@ describe('Validation middleware', () => {
       throw 4
     })
 
-    try {
-      validationMiddleware(mockSchema)(req, res, next)
-    } catch (err) {
-      expect(err).toEqual(4)
-    }
+    expect(() => validationMiddleware(mockSchema)(req, res, next)).toThrow(new Error(4))
 
     expect(validateFunc.length).toHaveBeenCalledWith('test1', mockSchema.test1.length, req.body.test1)
   })
@@ -129,11 +115,7 @@ describe('Validation middleware', () => {
       throw 5
     })
 
-    try {
-      validationMiddleware(mockSchema)(req, res, next)
-    } catch (err) {
-      expect(err).toEqual(5)
-    }
+    expect(() => validationMiddleware(mockSchema)(req, res, next)).toThrow(new Error(5))
 
     expect(validateFunc.regex).toHaveBeenCalledWith('test1', mockSchema.test1.regex, req.body.test1)
   })
@@ -147,11 +129,7 @@ describe('Validation middleware', () => {
       throw 6
     })
 
-    try {
-      validationMiddleware(mockSchema)(req, res, next)
-    } catch (err) {
-      expect(err).toEqual(6)
-    }
+    expect(() => validationMiddleware(mockSchema)(req, res, next)).toThrow(new Error(6))
 
     expect(validateFunc.enum).toHaveBeenCalledWith('test1', mockSchema.test1.enum, req.body.test1)
   })
@@ -160,11 +138,9 @@ describe('Validation middleware', () => {
     validateRequired.mockImplementation(() => {
       throw 2
     })
-    try {
-      validationMiddleware(mockSchema)(req, res, next)
-    } catch (err) {
-      expect(err).toBeDefined()
-    }
+
+    expect(() => validationMiddleware(mockSchema)(req, res, next)).toThrow(new Error(2))
+
     expect(next).not.toHaveBeenCalled()
   })
 

--- a/src/test/unit/middlewares/validation.spec.js
+++ b/src/test/unit/middlewares/validation.spec.js
@@ -163,8 +163,9 @@ describe('Validation middleware', () => {
     try {
       validationMiddleware(mockSchema)(req, res, next)
     } catch (err) {
-      expect(next).not.toHaveBeenCalled()
+      expect(err).toBeDefined()
     }
+    expect(next).not.toHaveBeenCalled()
   })
 
   it('Should call next function when everything is good', () => {

--- a/src/test/unit/middlewares/validation.spec.js
+++ b/src/test/unit/middlewares/validation.spec.js
@@ -1,0 +1,146 @@
+jest.mock('~/utils/errorsHelper')
+jest.mock('~/consts/errors', () => ({
+  BODY_IS_NOT_DEFINED: 1,
+  FIELD_IS_NOT_DEFINED: () => 2,
+  FIELD_IS_NOT_OF_PROPER_TYPE: () => 3,
+  FIELD_IS_NOT_OF_PROPER_LENGTH: () => 4,
+  FIELD_IS_NOT_OF_PROPER_FORMAT: () => 5,
+  FIELD_IS_NOT_OF_PROPER_ENUM_VALUE: () => 6
+}))
+
+const { createError } = require('~/utils/errorsHelper')
+
+const validationMiddleware = require('~/middlewares/validation')
+
+const TestEnum = ['testvalue']
+
+describe('Validation middleware', () => {
+  const mockSchema = {
+    test1: {
+      required: true,
+      type: 'string',
+      length: {
+        min: 5,
+        max: 15
+      },
+      regex: /^[a-zA-Z]+$/,
+      enum: TestEnum
+    }
+  }
+
+  let req
+  let res
+  let next
+
+  beforeEach(() => {
+    req = { body: {} }
+    res = {}
+    next = jest.fn()
+
+    createError.mockImplementation((statusCode, message) => {
+      return message
+    })
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('Should return error when body is not present', () => {
+    req.body = null
+
+    try {
+      validationMiddleware({})(req, res, next)
+    } catch (err) {
+      expect(err).toEqual(1)
+    }
+  })
+
+  it('Should return error when required field is not present', () => {
+    try {
+      validationMiddleware(mockSchema)(req, res, next)
+    } catch (err) {
+      expect(err).toEqual(2)
+    }
+  })
+
+  it('Should return error when field has wrong type', () => {
+    req.body = {
+      test1: 1
+    }
+
+    try {
+      validationMiddleware(mockSchema)(req, res, next)
+    } catch (err) {
+      expect(err).toEqual(3)
+    }
+  })
+
+  it('Should return error when field has wrong length', () => {
+    req.body = {
+      test1: '123'
+    }
+
+    try {
+      validationMiddleware(mockSchema)(req, res, next)
+    } catch (err) {
+      expect(err).toEqual(4)
+    }
+  })
+
+  it("Should return error when field doesn't match regex", () => {
+    req.body = {
+      test1: 'abcd123'
+    }
+
+    try {
+      validationMiddleware(mockSchema)(req, res, next)
+    } catch (err) {
+      expect(err).toEqual(5)
+    }
+  })
+
+  it("Should return error when field isn't enum value", () => {
+    req.body = {
+      test1: 'testtest'
+    }
+
+    try {
+      validationMiddleware(mockSchema)(req, res, next)
+    } catch (err) {
+      expect(err).toEqual(6)
+    }
+  })
+
+  it('Should not call next function when error appear', () => {
+    try {
+      validationMiddleware(mockSchema)(req, res, next)
+    } catch (err) {
+      expect(next).not.toHaveBeenCalled()
+    }
+  })
+
+  it('Should call next function when everything is good', () => {
+    req.body = {
+      test1: 'testvalue'
+    }
+
+    try {
+      validationMiddleware(mockSchema)(req, res, next)
+    } catch (err) {
+      expect(err).not.toBeDefined()
+    }
+
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('Should call next function when schema is empty', () => {
+    req.body = {
+      test1: 'testtest'
+    }
+
+    validationMiddleware({})(req, res, next)
+
+    expect(next).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
added validation middleware tests.
The test consist of nine checks

1. Should return error when body is not present 
2. Should return error when required field is not present 
3. Should call next when empty field is not required
4. Should return error when field has wrong type 
5. Should return error when field has wrong length 
6. Should return error when field doesn't match regex 
7. Should return error when field isn't enum value 
8. Should not call next function when error appear 
9. Should call next function when everything is good 
10. Should call next function when schema is empty 

To run test execute
 ```bash
npm test validation.spec.js
 ```