### PR TITLE
eslint line separators complain fix

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,7 +11,6 @@
   },
   "rules": {
     "indent": ["error", 2],
-    "linebreak-style": ["error", "windows"],
     "quotes": ["error", "single"],
     "semi": ["error", "never"],
     "eol-last": ["error", "always"],

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.js text eol=lf


### PR DESCRIPTION
ESLint will not complain about difference in line separators,
But if separators were changed, it will be automatically set to LP (`\n` - unix system)

<img width="840" alt="Знімок екрана 2024-07-19 о 22 41 48" src="https://github.com/user-attachments/assets/6f78561d-7ac5-40b7-98fa-450e3c562bde">
