### PR TITLE
Bug #12: added case insensitivity to the category search

### DIFF
--- a/src/controllers/resourcesCategory.js
+++ b/src/controllers/resourcesCategory.js
@@ -16,7 +16,7 @@ const getResourcesCategories = async (req, res) => {
   const { id: author } = req.user
   const { name, sort, skip, limit } = req.query
 
-  const match = getMatchOptions({ author, name: { ...getRegex(name), $options: 'i' } }) //added case insensitivity
+  const match = getMatchOptions({ author, name: { ...getRegex(name), $options: 'i' } })
   const sortOptions = getSortOptions(sort)
 
   const resourcesCategories = await resourcesCategoryService.getResourcesCategories(

--- a/src/controllers/resourcesCategory.js
+++ b/src/controllers/resourcesCategory.js
@@ -16,7 +16,7 @@ const getResourcesCategories = async (req, res) => {
   const { id: author } = req.user
   const { name, sort, skip, limit } = req.query
 
-  const match = getMatchOptions({ author, name: getRegex(name) })
+  const match = getMatchOptions({ author, name: { ...getRegex(name), $options: 'i' } }) //added case insensitivity
   const sortOptions = getSortOptions(sort)
 
   const resourcesCategories = await resourcesCategoryService.getResourcesCategories(


### PR DESCRIPTION
Pretty straightforward, only one line of code is changed.

To test the difference (on develop branch and/or after doing "git checkout bug/12/make-search-case-insensitive "):
1. Log in as tutor
2. Go to "My Resources" http://localhost:3000/my-resources => Categories => create some categories with upper- and lowercase
3. Use the search field. Notice that the search is case-sensitive on develop and case-insensitive (bugfix) on this new branch.

Also:
— apparently the search doesn't support spaces (not sure if intended or a separate bug)
— "Questions" also has a search field, but I was unable to test anything there ("Save" button stays inactive when I try to create a question), and from the description of the bug I'm not sure if only category search is affected, or is it category+question... if it's the latter, I guess I could hold the issue for longer until question saving is fixed, and then touch this bug again.