### PR TITLE
Bugfix #14

### DIFF
--- a/src/utils/getCategoriesOption.js
+++ b/src/utils/getCategoriesOption.js
@@ -1,6 +1,8 @@
 const getCategoriesOptions = (categories) => {
-  if (categories) {
+  if (Array.isArray(categories)) {
     return categories.map((item) => (item === 'null' ? null : item))
+  } else if (categories) {
+    return categories === 'null' ? null : [categories]
   } else {
     return
   }


### PR DESCRIPTION
The essence of the bug is that when multiple categories are enabled, they are passed as an array ['id1', 'id2'], while a single category is passed as a string 'id1', thus producing a "map is not a function" error. My changes add a code that converts single element 'id1' into ['id1'] before passing it for further processing.

To verify the changes on the original branch and/or after "git checkout bug/14/fix-category-map":
1. Log in as tutor, go to "My resources" http://localhost:3000/my-resources => Categories, and create a few categories there.
2. Go to a neighbouring tab "Questions", click on "Category: All" to open a list of categories, and enable one category.
3. Notice it will produce an error on original branch, and will no longer produce an error on bug/14/fix-category-map branch.