### PR TITLE
#55: updated swagger documentation with email confirmation

### DIFF
--- a/src/docs/paths/auth.yaml
+++ b/src/docs/paths/auth.yaml
@@ -128,6 +128,21 @@ paths:
           description: "No Content: Password updated successfully"
         '400':
           description: "Bad request: Invalid password format"
+  /auth/confirm-email/{token}:
+    patch:
+      summary: "Confirm Email"
+      description: "Confirm user's email after registration"
+      parameters:
+        - in: path
+          name: token
+          required: true
+          description: "Email confirmation token"
+          type: string
+      responses:
+        '200':
+          description: "No Content: Email confirmed successfully"
+        '400':
+          description: "Bad request: Error confirming email"
 
   /auth/google-auth:
     post:


### PR DESCRIPTION
Just some auth.yaml changes with accordance to task #22 (email confirmation)
As a reminder, you can check swagger documentation at http://localhost:8080/api-docs/