### PR TITLE
Feature/77/create get subjects endpoint

### DIFF
--- a/src/consts/models.js
+++ b/src/consts/models.js
@@ -12,7 +12,8 @@ const refs = {
   FINISHED_QUIZ: 'FinishedQuiz',
   ATTACHMENT: 'Attachment',
   QUESTION: 'Question',
-  RESOURCES_CATEGORY: 'ResourcesCategory'
+  RESOURCES_CATEGORY: 'ResourcesCategory',
+  CATEGORY: 'Category'
 }
 
 module.exports = refs

--- a/src/controllers/subject.js
+++ b/src/controllers/subject.js
@@ -1,0 +1,11 @@
+const subjectService = require('~/services/subject')
+
+const getSubjects = async (req, res) => {
+  const subjects = await subjectService.getSubjects()
+
+  res.status(200).json(subjects)
+}
+
+module.exports = {
+  getSubjects
+}

--- a/src/models/subject.js
+++ b/src/models/subject.js
@@ -1,0 +1,21 @@
+const { Schema, model } = require('mongoose')
+
+const { SUBJECT, CATEGORY } = require('~/consts/models')
+const { FIELD_CANNOT_BE_EMPTY } = require('~/consts/errors')
+
+const subjectSchema = new Schema(
+  {
+    name: {
+      type: String,
+      required: [true, FIELD_CANNOT_BE_EMPTY('name')],
+      unique: true
+    },
+    сategory: {
+      type: Schema.Types.ObjectId,
+      ref: CATEGORY
+    }
+  },
+  { timestamps: true, versionKey: false }
+)
+
+module.exports = model(SUBJECT, subjectSchema)

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -10,6 +10,7 @@ const offer = require('~/routes/offer')
 const locationServiceCountries = require('~/routes/locationServiceCountries')
 const locationServiceCities = require('~/routes/locationServiceCities')
 const constants = require('~/routes/constants')
+const subjects = require('~/routes/subject')
 
 router.use('/auth', auth)
 router.use('/users', user)
@@ -21,5 +22,6 @@ router.use('/offers', offer)
 router.use('/get-country-list', locationServiceCountries)
 router.use('/get-city-list', locationServiceCities)
 router.use('/constants', constants)
+router.use('/subjects', subjects)
 
 module.exports = router

--- a/src/routes/subject.js
+++ b/src/routes/subject.js
@@ -1,0 +1,12 @@
+const router = require('express').Router({ mergeParams: true })
+
+const asyncWrapper = require('~/middlewares/asyncWrapper')
+const { authMiddleware } = require('~/middlewares/auth')
+
+const subjectController = require('~/controllers/subject')
+
+router.use(authMiddleware)
+
+router.get('/', asyncWrapper(subjectController.getSubjects))
+
+module.exports = router

--- a/src/services/subject.js
+++ b/src/services/subject.js
@@ -1,0 +1,16 @@
+const Subject = require('~/models/subject')
+const { createError } = require('../utils/errorsHelper')
+const { INTERNAL_SERVER_ERROR } = require('~/consts/errors')
+
+const subjectService = {
+  getSubjects: async () => {
+    try {
+      const subjects = await Subject.find().exec()
+      return subjects
+    } catch (error) {
+      throw createError(500, INTERNAL_SERVER_ERROR)
+    }
+  }
+}
+
+module.exports = subjectService

--- a/src/test/unit/services/subject.spec.js
+++ b/src/test/unit/services/subject.spec.js
@@ -39,5 +39,17 @@ describe('subjectService', () => {
       await expect(subjectService.getSubjects()).rejects.toEqual(mockError)
       expect(createError).toHaveBeenCalledWith(500, INTERNAL_SERVER_ERROR)
     })
+
+    it('should return an empty array when no subjects are found', async () => {
+      Subject.find.mockReturnValue({
+        exec: jest.fn().mockResolvedValue([])
+      })
+
+      const subjects = await subjectService.getSubjects()
+
+      expect(subjects).toEqual([])
+      expect(Subject.find).toHaveBeenCalledTimes(1)
+      expect(Subject.find().exec).toHaveBeenCalledTimes(1)
+    })
   })
 })

--- a/src/test/unit/services/subject.spec.js
+++ b/src/test/unit/services/subject.spec.js
@@ -1,0 +1,43 @@
+const Subject = require('~/models/subject')
+const subjectService = require('~/services/subject')
+const { createError } = require('~/utils/errorsHelper')
+const { INTERNAL_SERVER_ERROR } = require('~/consts/errors')
+
+jest.mock('~/models/subject')
+jest.mock('~/utils/errorsHelper', () => ({
+  createError: jest.fn()
+}))
+
+describe('subjectService', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('getSubjects', () => {
+    it('should return subjects when find is successful', async () => {
+      const mockSubjects = [{ name: 'Math' }, { name: 'Science' }]
+      Subject.find.mockReturnValue({
+        exec: jest.fn().mockResolvedValue(mockSubjects)
+      })
+
+      const subjects = await subjectService.getSubjects()
+
+      expect(subjects).toBe(mockSubjects)
+      expect(Subject.find).toHaveBeenCalledTimes(1)
+      expect(Subject.find().exec).toHaveBeenCalledTimes(1)
+    })
+
+    it('should throw an error when find fails', async () => {
+      const error = new Error('Database error')
+      Subject.find.mockReturnValue({
+        exec: jest.fn().mockRejectedValue(error)
+      })
+
+      const mockError = createError(500, INTERNAL_SERVER_ERROR)
+      createError.mockReturnValue(mockError)
+
+      await expect(subjectService.getSubjects()).rejects.toEqual(mockError)
+      expect(createError).toHaveBeenCalledWith(500, INTERNAL_SERVER_ERROR)
+    })
+  })
+})


### PR DESCRIPTION
Task completed without swagger documentation, will add separate task for creating swagger doc.

![image](https://github.com/user-attachments/assets/1c3c5df9-bee5-4869-ad8b-da5c00e9bcfd)
to run tests:
npm run test subject