### PR TITLE
added category route, service, controller, added categories endpoint

### DIFF
--- a/src/controllers/category.js
+++ b/src/controllers/category.js
@@ -1,0 +1,14 @@
+const categoryService = require('~/services/category')
+const getSortOptions = require('~/utils/getSortOptions')
+const getCategories = async (req, res) => {
+  const { sort, skip, limit } = req.query
+
+  const sortOptions = getSortOptions(sort)
+  const categories = await categoryService.getCategories(sortOptions, parseInt(skip), parseInt(limit))
+
+  res.status(200).json(categories)
+}
+
+module.exports = {
+  getCategories
+}

--- a/src/routes/category.js
+++ b/src/routes/category.js
@@ -1,0 +1,14 @@
+const router = require('express').Router({ mergeParams: true })
+
+const asyncWrapper = require('~/middlewares/asyncWrapper')
+const { authMiddleware } = require('~/middlewares/auth')
+
+const categoryController = require('~/controllers/category')
+// eslint-disable-next-line no-unused-vars
+const Category = require('~/models/category')
+
+router.use(authMiddleware)
+
+router.get('/', asyncWrapper(categoryController.getCategories))
+
+module.exports = router

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -10,7 +10,8 @@ const offer = require('~/routes/offer')
 const locationServiceCountries = require('~/routes/locationServiceCountries')
 const locationServiceCities = require('~/routes/locationServiceCities')
 const constants = require('~/routes/constants')
-const subjects = require('~/routes/subject')
+const category = require('~/routes/category')
+const subject = require('~/routes/subject')
 
 router.use('/auth', auth)
 router.use('/users', user)
@@ -22,6 +23,7 @@ router.use('/offers', offer)
 router.use('/get-country-list', locationServiceCountries)
 router.use('/get-city-list', locationServiceCities)
 router.use('/constants', constants)
-router.use('/subjects', subjects)
+router.use('/categories', category)
+router.use('/subjects', subject)
 
 module.exports = router

--- a/src/routes/subject.js
+++ b/src/routes/subject.js
@@ -8,10 +8,6 @@ const isEntityValid = require('~/middlewares/entityValidation')
 const subjectController = require('~/controllers/subject')
 const Subject = require('~/models/subject')
 
-/*TEMP SOLUTION replace to category route when it appears*/
-// eslint-disable-next-line no-unused-vars
-const Category = require('~/models/category')
-
 const {
   roles: { ADMIN }
 } = require('~/consts/auth')

--- a/src/services/category.js
+++ b/src/services/category.js
@@ -1,0 +1,16 @@
+const Category = require('~/models/category')
+const { createError } = require('~/utils/errorsHelper')
+const { INTERNAL_SERVER_ERROR } = require('~/consts/errors')
+
+const categoryService = {
+  getCategories: async (sort, skip = 0, limit = 10) => {
+    try {
+      const categories = await Category.find().sort(sort).skip(skip).limit(limit).lean().exec()
+      return categories
+    } catch (error) {
+      throw createError(500, INTERNAL_SERVER_ERROR)
+    }
+  }
+}
+
+module.exports = categoryService

--- a/src/test/unit/services/category.spec.js
+++ b/src/test/unit/services/category.spec.js
@@ -1,0 +1,45 @@
+const categoryService = require('~/services/category')
+const Category = require('~/models/category')
+const { createError } = require('~/utils/errorsHelper')
+const { INTERNAL_SERVER_ERROR } = require('~/consts/errors')
+
+jest.mock('~/models/category')
+jest.mock('~/utils/errorsHelper')
+
+describe('categoryService', () => {
+  describe('getCategories', () => {
+    it('should return categories when called with valid arguments', async () => {
+      const mockCategories = [{ name: 'Category 1' }, { name: 'Category 2' }]
+      Category.find.mockReturnValue({
+        sort: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        lean: jest.fn().mockReturnThis(),
+        exec: jest.fn().mockResolvedValue(mockCategories)
+      })
+
+      const result = await categoryService.getCategories('name', 0, 10)
+
+      expect(result).toEqual(mockCategories)
+      expect(Category.find).toHaveBeenCalled()
+      expect(Category.find().sort).toHaveBeenCalledWith('name')
+      expect(Category.find().sort().skip).toHaveBeenCalledWith(0)
+      expect(Category.find().sort().skip().limit).toHaveBeenCalledWith(10)
+    })
+
+    it('should throw a 500 error if an error occurs during fetching categories', async () => {
+      const error = new Error('Database error')
+      Category.find.mockReturnValue({
+        sort: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        lean: jest.fn().mockReturnThis(),
+        exec: jest.fn().mockRejectedValue(error)
+      })
+      createError.mockReturnValue(new Error(INTERNAL_SERVER_ERROR))
+
+      await expect(categoryService.getCategories('name')).rejects.toThrow(new Error(INTERNAL_SERVER_ERROR))
+      expect(createError).toHaveBeenCalledWith(500, INTERNAL_SERVER_ERROR)
+    })
+  })
+})


### PR DESCRIPTION
Added possibility to getCategories with sort,skip,limit params, added unit test for category service.
Swagger doc will be added with separate task.
![image](https://github.com/user-attachments/assets/6692e2b5-2c3f-4447-b4d1-abe5e3099b2f)

to run tests:
npm run test category