### PR TITLE
commit for #76 backend

### DIFF
--- a/src/consts/errors.js
+++ b/src/consts/errors.js
@@ -3,6 +3,10 @@ const {
 } = require('~/consts/validation')
 
 const errors = {
+  CATEGORY_ALREADY_EXISTS: {
+    code: 'CATEGORY_ALREADY_EXISTS',
+    message: 'Category cannot be added, as it already exists in the database.'
+  },
   COUNTRYSTATECITY_API_ISSUE: {
     code: 'COUNTRYSTATECITY_API_ISSUE',
     message: 'Some issue occurred while polling CountryStateCity.in API.'

--- a/src/controllers/category.js
+++ b/src/controllers/category.js
@@ -10,6 +10,11 @@ const getCategories = async (req, res) => {
   res.status(200).json(categories)
 }
 
+const addCategory = async (req, res) => {
+  const newCategory = await categoryService.addCategory(req, res)
+  res.status(200).json(newCategory)
+}
+
 const getSubjectsNamesByCategoryId = async (req, res) => {
   const { id } = req.params
 
@@ -19,5 +24,6 @@ const getSubjectsNamesByCategoryId = async (req, res) => {
 
 module.exports = {
   getCategories,
+  addCategory,
   getSubjectsNamesByCategoryId
 }

--- a/src/docs/paths/categoryService.yaml
+++ b/src/docs/paths/categoryService.yaml
@@ -1,0 +1,16 @@
+paths:
+  /categories:
+    post:
+      summary: "Add category"
+      description: "Add category to the list of categories in the database"
+      responses:
+        '200':
+          description: "OK: a created category is returned"
+        '401':
+          description: "Unauthorized (adding categories requires being authorized as ADMIN)"
+        '403':
+          description: "Forbidden (adding categories requires being authorized as *ADMIN*)"
+        '409':
+          description: "Category already exists in the database"
+        '500':
+          description: "Something went wrong while adding the category (likely validation error)"

--- a/src/routes/category.js
+++ b/src/routes/category.js
@@ -2,7 +2,7 @@ const router = require('express').Router({ mergeParams: true })
 
 const idValidation = require('~/middlewares/idValidation')
 const asyncWrapper = require('~/middlewares/asyncWrapper')
-const { authMiddleware } = require('~/middlewares/auth')
+const { restrictTo, authMiddleware } = require('~/middlewares/auth')
 const isEntityValid = require('~/middlewares/entityValidation')
 
 const categoryController = require('~/controllers/category')
@@ -11,11 +11,18 @@ const Category = require('~/models/category')
 
 const params = [{ model: Category, idName: 'id' }]
 
+const {
+  roles: { ADMIN }
+} = require('~/consts/auth')
+
 router.use(authMiddleware)
 
 router.param('id', idValidation)
 
 router.get('/', asyncWrapper(categoryController.getCategories))
 router.get('/:id/subjects/names', isEntityValid({ params }), categoryController.getSubjectsNamesByCategoryId)
+
+router.use(restrictTo(ADMIN))
+router.post('/', asyncWrapper(categoryController.addCategory))
 
 module.exports = router

--- a/src/services/category.js
+++ b/src/services/category.js
@@ -1,7 +1,7 @@
 const Category = require('~/models/category')
 const Subject = require('~/models/subject')
 const { createError } = require('~/utils/errorsHelper')
-const { INTERNAL_SERVER_ERROR } = require('~/consts/errors')
+const { CATEGORY_ALREADY_EXISTS, INTERNAL_SERVER_ERROR } = require('~/consts/errors')
 
 const categoryService = {
   getCategories: async (sort, skip = 0, limit = 10) => {
@@ -9,6 +9,22 @@ const categoryService = {
       const categories = await Category.find().sort(sort).skip(skip).limit(limit).lean().exec()
       const count = await Category.countDocuments()
       return { count, categories }
+    } catch (error) {
+      throw createError(500, INTERNAL_SERVER_ERROR)
+    }
+  },
+
+  addCategory: async (req, _res) => {
+    try {
+      const existingEntry = await Category.findOne(req.body)
+      if (existingEntry) throw 'error'
+    } catch {
+      throw createError(409, CATEGORY_ALREADY_EXISTS)
+    }
+
+    try {
+      const newCategory = await Category.create(req.body)
+      return { newCategory }
     } catch (error) {
       throw createError(500, INTERNAL_SERVER_ERROR)
     }


### PR DESCRIPTION
Per task description, a POST method is added for /categories endpoint to add categories.
Swagger docs are included. Tests are *not* included.

You should authorize as ADMIN (for example, via /auth/login endpoint using Postman), and then you can send a request.
Example of a simpliest one: {"name": "category 1"}. In case of success, a newly created category is returned.
As covered in Swagger docs, you can receive 200 (ok), 401 (unauthorized), 403 (forbidden), 409 (already exists), 500 (validation).