### PR TITLE
Backend #75 (get category by id)

### DIFF
--- a/src/consts/errors.js
+++ b/src/consts/errors.js
@@ -3,6 +3,10 @@ const {
 } = require('~/consts/validation')
 
 const errors = {
+  CATEGORY_ALREADY_EXISTS: {
+    code: 'CATEGORY_ALREADY_EXISTS',
+    message: 'Category cannot be added, as it already exists in the database.'
+  },
   COUNTRYSTATECITY_API_ISSUE: {
     code: 'COUNTRYSTATECITY_API_ISSUE',
     message: 'Some issue occurred while polling CountryStateCity.in API.'

--- a/src/consts/errors.js
+++ b/src/consts/errors.js
@@ -7,6 +7,10 @@ const errors = {
     code: 'CATEGORY_ALREADY_EXISTS',
     message: 'Category cannot be added, as it already exists in the database.'
   },
+  CATEGORY_NOT_FOUND: {
+    code: 'CATEGORY_NOT_FOUND',
+    message: 'Category with the specified ID was not found.'
+  },
   COUNTRYSTATECITY_API_ISSUE: {
     code: 'COUNTRYSTATECITY_API_ISSUE',
     message: 'Some issue occurred while polling CountryStateCity.in API.'

--- a/src/controllers/category.js
+++ b/src/controllers/category.js
@@ -10,6 +10,11 @@ const getCategories = async (req, res) => {
   res.status(200).json(categories)
 }
 
+const getCategoryById = async (req, res) => {
+  const category = await categoryService.getCategoryById(req, res)
+  res.status(200).json(category)
+}
+
 const addCategory = async (req, res) => {
   const newCategory = await categoryService.addCategory(req, res)
   res.status(200).json(newCategory)
@@ -24,6 +29,7 @@ const getSubjectsNamesByCategoryId = async (req, res) => {
 
 module.exports = {
   getCategories,
+  getCategoryById,
   addCategory,
   getSubjectsNamesByCategoryId
 }

--- a/src/controllers/category.js
+++ b/src/controllers/category.js
@@ -10,6 +10,11 @@ const getCategories = async (req, res) => {
   res.status(200).json(categories)
 }
 
+const addCategory = async (req, res) => {
+  const newCategory = await categoryService.addCategory(req, res)
+  res.status(200).json(newCategory)
+}
+
 const getSubjectsNamesByCategoryId = async (req, res) => {
   const { id } = req.params
 
@@ -19,5 +24,6 @@ const getSubjectsNamesByCategoryId = async (req, res) => {
 
 module.exports = {
   getCategories,
+  addCategory,
   getSubjectsNamesByCategoryId
 }

--- a/src/docs/paths/categoryService.yaml
+++ b/src/docs/paths/categoryService.yaml
@@ -14,3 +14,16 @@ paths:
           description: "Category already exists in the database"
         '500':
           description: "Something went wrong while adding the category (likely validation error)"
+  /categories/{id}:
+    post:
+      summary: "Get category by ID"
+      description: "Find category in the database by its ID"
+      responses:
+        '200':
+          description: "OK: a category is found and returned"
+        '401':
+          description: "Unauthorized (need to be authorized with any role)"
+        '404':
+          description: "Category is not found by the specified ID"
+        '500':
+          description: "Something went wrong while looking up the category by ID (probably shouldn't happen normally)"

--- a/src/docs/paths/categoryService.yaml
+++ b/src/docs/paths/categoryService.yaml
@@ -1,0 +1,16 @@
+paths:
+  /categories:
+    post:
+      summary: "Add category"
+      description: "Add category to the list of categories in the database"
+      responses:
+        '200':
+          description: "OK: a created category is returned"
+        '401':
+          description: "Unauthorized (adding categories requires being authorized as ADMIN)"
+        '403':
+          description: "Forbidden (adding categories requires being authorized as *ADMIN*)"
+        '409':
+          description: "Category already exists in the database"
+        '500':
+          description: "Something went wrong while adding the category (likely validation error)"

--- a/src/routes/category.js
+++ b/src/routes/category.js
@@ -2,7 +2,7 @@ const router = require('express').Router({ mergeParams: true })
 
 const idValidation = require('~/middlewares/idValidation')
 const asyncWrapper = require('~/middlewares/asyncWrapper')
-const { authMiddleware } = require('~/middlewares/auth')
+const { restrictTo, authMiddleware } = require('~/middlewares/auth')
 const isEntityValid = require('~/middlewares/entityValidation')
 
 const categoryController = require('~/controllers/category')
@@ -11,11 +11,18 @@ const Category = require('~/models/category')
 
 const params = [{ model: Category, idName: 'id' }]
 
+const {
+  roles: { ADMIN }
+} = require('~/consts/auth')
+
 router.use(authMiddleware)
 
 router.param('id', idValidation)
 
 router.get('/', asyncWrapper(categoryController.getCategories))
 router.get('/:id/subjects/names', isEntityValid({ params }), categoryController.getSubjectsNamesByCategoryId)
+
+router.use(restrictTo(ADMIN))
+router.post('/', asyncWrapper(categoryController.addCategory))
 
 module.exports = router

--- a/src/routes/category.js
+++ b/src/routes/category.js
@@ -20,6 +20,7 @@ router.use(authMiddleware)
 router.param('id', idValidation)
 
 router.get('/', asyncWrapper(categoryController.getCategories))
+router.get('/:id', asyncWrapper(categoryController.getCategoryById))
 router.get('/:id/subjects/names', isEntityValid({ params }), categoryController.getSubjectsNamesByCategoryId)
 
 router.use(restrictTo(ADMIN))

--- a/src/services/category.js
+++ b/src/services/category.js
@@ -1,7 +1,7 @@
 const Category = require('~/models/category')
 const Subject = require('~/models/subject')
 const { createError } = require('~/utils/errorsHelper')
-const { INTERNAL_SERVER_ERROR } = require('~/consts/errors')
+const { CATEGORY_ALREADY_EXISTS, INTERNAL_SERVER_ERROR } = require('~/consts/errors')
 
 const categoryService = {
   getCategories: async (sort, skip = 0, limit = 10) => {
@@ -9,6 +9,22 @@ const categoryService = {
       const categories = await Category.find().sort(sort).skip(skip).limit(limit).lean().exec()
       const count = await Category.countDocuments()
       return { count, categories }
+    } catch (error) {
+      throw createError(500, INTERNAL_SERVER_ERROR)
+    }
+  },
+
+  addCategory: async (req, _res) => {
+    try {
+      const existingEntry = await Category.findOne(req.body)
+      if (existingEntry) throw 'error'
+    } catch {
+      throw createError(409, CATEGORY_ALREADY_EXISTS)
+    }
+
+    try {
+      const newCategory = await Category.create(req.body)
+      return { newCategory }
     } catch (error) {
       throw createError(500, INTERNAL_SERVER_ERROR)
     }

--- a/src/services/category.js
+++ b/src/services/category.js
@@ -1,7 +1,7 @@
 const Category = require('~/models/category')
 const Subject = require('~/models/subject')
 const { createError } = require('~/utils/errorsHelper')
-const { CATEGORY_ALREADY_EXISTS, INTERNAL_SERVER_ERROR } = require('~/consts/errors')
+const { CATEGORY_NOT_FOUND, CATEGORY_ALREADY_EXISTS, INTERNAL_SERVER_ERROR } = require('~/consts/errors')
 
 const categoryService = {
   getCategories: async (sort, skip = 0, limit = 10) => {
@@ -11,6 +11,16 @@ const categoryService = {
       return { count, categories }
     } catch (error) {
       throw createError(500, INTERNAL_SERVER_ERROR)
+    }
+  },
+
+  getCategoryById: async (req, _res) => {
+    try {
+      const category = await Category.findById(req.params.id)
+      if (!category) throw 'error'
+      return category
+    } catch {
+      throw createError(404, CATEGORY_NOT_FOUND)
     }
   },
 


### PR DESCRIPTION
Per task description, a backend endpoint /categories/:id is created. You should be authorized with any role to view the result.
Can return 200 OK with the found category, 401 (unauthorized), 404 (not found by ID), 500 (theoretically, it should never, though)
Swagger docs are added. Tests are *not* added.