### PR TITLE
get category names endpoint

### DIFF
--- a/src/controllers/category.js
+++ b/src/controllers/category.js
@@ -17,7 +17,14 @@ const getSubjectsNamesByCategoryId = async (req, res) => {
   res.status(200).json(subjectsNames)
 }
 
+const getCategoryNames = async (req, res) => {
+  const categoryNames = await categoryService.getCategoryNames()
+
+  res.status(200).json(categoryNames)
+}
+
 module.exports = {
   getCategories,
-  getSubjectsNamesByCategoryId
+  getSubjectsNamesByCategoryId,
+  getCategoryNames
 }

--- a/src/docs/paths/categories.yaml
+++ b/src/docs/paths/categories.yaml
@@ -1,0 +1,30 @@
+paths:
+  /categories/names:
+    get:
+      summary: "Get categories names"
+      description: "Endpoint for getting all categories names. Protected - accessible only for authorized users"
+      responses:
+        '200':
+          description: "Success: categories list is returned"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  categoryNames:
+                    type: array
+                    description: "array of objects with _id and name of category"
+                    items:
+                      type: object
+                      properties:
+                        _id:
+                          type: string
+                        name:
+                          type: string
+                  count:
+                    type: number
+                    description: "Amount of category names that are returned"
+        '401':
+          description: "Unauthorized: invalid access token"
+        '404':
+          description: "Not found: returned when error occurs during request to DB"

--- a/src/mocks/categoriesMock.json
+++ b/src/mocks/categoriesMock.json
@@ -1,6 +1,6 @@
 [
   {
-    "_id": "64dfe0b9bcf86cd799439012",
+    "_id": { "$oid": "64dfe0b9bcf86cd799439012" },
     "name": "Languages",
     "appearance": {
       "icon": "mocked-path-to-icon",
@@ -10,7 +10,7 @@
     "updatedAt": "2024-08-15T08:45:21.236Z"
   },
   {
-    "_id": "64dfe0b9bcf86cd799439013",
+    "_id": { "$oid": "64dfe0b9bcf86cd799439013" },
     "name": "Mathematics",
     "appearance": {
       "icon": "mocked-path-to-icon",
@@ -20,7 +20,7 @@
     "updatedAt": "2024-08-15T08:45:21.236Z"
   },
   {
-    "_id": "64dfe0b9bcf86cd799439014",
+    "_id": { "$oid": "64dfe0b9bcf86cd799439014" },
     "name": "Computer science",
     "appearance": {
       "icon": "mocked-path-to-icon",
@@ -30,7 +30,7 @@
     "updatedAt": "2024-08-15T08:45:21.236Z"
   },
   {
-    "_id": "64dfe0b9bcf86cd799439015",
+    "_id": { "$oid": "64dfe0b9bcf86cd799439015" },
     "name": "Music",
     "appearance": {
       "icon": "mocked-path-to-icon",
@@ -40,7 +40,7 @@
     "updatedAt": "2024-08-15T08:45:21.236Z"
   },
   {
-    "_id": "64dfe0b9bcf86cd799439016",
+    "_id": { "$oid": "64dfe0b9bcf86cd799439016" },
     "name": "History",
     "appearance": {
       "icon": "mocked-path-to-icon",

--- a/src/mocks/categoriesMock.json
+++ b/src/mocks/categoriesMock.json
@@ -1,0 +1,52 @@
+[
+  {
+    "_id": "64dfe0b9bcf86cd799439012",
+    "name": "Languages",
+    "appearance": {
+      "icon": "mocked-path-to-icon",
+      "color": "#66C42C"
+    },
+    "createdAt": "2024-08-15T08:45:21.236Z",
+    "updatedAt": "2024-08-15T08:45:21.236Z"
+  },
+  {
+    "_id": "64dfe0b9bcf86cd799439013",
+    "name": "Mathematics",
+    "appearance": {
+      "icon": "mocked-path-to-icon",
+      "color": "#66C42C"
+    },
+    "createdAt": "2024-08-15T08:45:21.236Z",
+    "updatedAt": "2024-08-15T08:45:21.236Z"
+  },
+  {
+    "_id": "64dfe0b9bcf86cd799439014",
+    "name": "Computer science",
+    "appearance": {
+      "icon": "mocked-path-to-icon",
+      "color": "#66C42C"
+    },
+    "createdAt": "2024-08-15T08:45:21.236Z",
+    "updatedAt": "2024-08-15T08:45:21.236Z"
+  },
+  {
+    "_id": "64dfe0b9bcf86cd799439015",
+    "name": "Music",
+    "appearance": {
+      "icon": "mocked-path-to-icon",
+      "color": "#66C42C"
+    },
+    "createdAt": "2024-08-15T08:45:21.236Z",
+    "updatedAt": "2024-08-15T08:45:21.236Z"
+  },
+  {
+    "_id": "64dfe0b9bcf86cd799439016",
+    "name": "History",
+    "appearance": {
+      "icon": "mocked-path-to-icon",
+      "color": "#66C42C"
+    },
+    "createdAt": "2024-08-15T08:45:21.236Z",
+    "updatedAt": "2024-08-15T08:45:21.236Z"
+  }
+]

--- a/src/mocks/subjectsMock.json
+++ b/src/mocks/subjectsMock.json
@@ -33,5 +33,19 @@
     "category": { "$oid": "64dfe0b9bcf86cd799439016" },
     "createdAt": "2024-08-15T09:04:00.000Z",
     "updatedAt": "2024-08-15T09:04:00.000Z"
+  },
+  {
+    "_id": { "$oid": "64dfe1b2bcf86cd79943901c" },
+    "name": "Ancient Civilizations",
+    "category": { "$oid": "64dfe0b9bcf86cd799439016" },
+    "createdAt": "2024-08-15T09:05:00.000Z",
+    "updatedAt": "2024-08-15T09:05:00.000Z"
+  },
+  {
+    "_id": { "$oid": "64dfe1b2bcf86cd79943901d" },
+    "name": "Renaissance Art",
+    "category": { "$oid": "64dfe0b9bcf86cd799439016" },
+    "createdAt": "2024-08-15T09:06:00.000Z",
+    "updatedAt": "2024-08-15T09:06:00.000Z"
   }
 ]

--- a/src/mocks/subjectsMock.json
+++ b/src/mocks/subjectsMock.json
@@ -1,0 +1,37 @@
+[
+  {
+    "_id": { "$oid": "64dfe1b2bcf86cd799439017" },
+    "name": "Spanish",
+    "category": { "$oid": "64dfe0b9bcf86cd799439012" },
+    "createdAt": "2024-08-15T09:00:00.000Z",
+    "updatedAt": "2024-08-15T09:00:00.000Z"
+  },
+  {
+    "_id": { "$oid": "64dfe1b2bcf86cd799439018" },
+    "name": "Calculus",
+    "category": { "$oid": "64dfe0b9bcf86cd799439013" },
+    "createdAt": "2024-08-15T09:01:00.000Z",
+    "updatedAt": "2024-08-15T09:01:00.000Z"
+  },
+  {
+    "_id": { "$oid": "64dfe1b2bcf86cd799439019" },
+    "name": "Algorithms",
+    "category": { "$oid": "64dfe0b9bcf86cd799439014" },
+    "createdAt": "2024-08-15T09:02:00.000Z",
+    "updatedAt": "2024-08-15T09:02:00.000Z"
+  },
+  {
+    "_id": { "$oid": "64dfe1b2bcf86cd79943901a" },
+    "name": "Piano",
+    "category": { "$oid": "64dfe0b9bcf86cd799439015" },
+    "createdAt": "2024-08-15T09:03:00.000Z",
+    "updatedAt": "2024-08-15T09:03:00.000Z"
+  },
+  {
+    "_id": { "$oid": "64dfe1b2bcf86cd79943901b" },
+    "name": "World War II",
+    "category": { "$oid": "64dfe0b9bcf86cd799439016" },
+    "createdAt": "2024-08-15T09:04:00.000Z",
+    "updatedAt": "2024-08-15T09:04:00.000Z"
+  }
+]

--- a/src/routes/category.js
+++ b/src/routes/category.js
@@ -18,4 +18,6 @@ router.param('id', idValidation)
 router.get('/', asyncWrapper(categoryController.getCategories))
 router.get('/:id/subjects/names', isEntityValid({ params }), categoryController.getSubjectsNamesByCategoryId)
 
+router.get('/names', asyncWrapper(categoryController.getCategoryNames))
+
 module.exports = router

--- a/src/services/category.js
+++ b/src/services/category.js
@@ -1,7 +1,7 @@
 const Category = require('~/models/category')
 const Subject = require('~/models/subject')
 const { createError } = require('~/utils/errorsHelper')
-const { INTERNAL_SERVER_ERROR } = require('~/consts/errors')
+const { INTERNAL_SERVER_ERROR, NOT_FOUND } = require('~/consts/errors')
 
 const categoryService = {
   getCategories: async (sort, skip = 0, limit = 10) => {
@@ -13,7 +13,6 @@ const categoryService = {
       throw createError(500, INTERNAL_SERVER_ERROR)
     }
   },
-
   getSubjectsNameByCategoryId: async (categoryId) => {
     try {
       const subjects = await Subject.find({ category: categoryId }, '_id, name').lean().exec()
@@ -21,6 +20,16 @@ const categoryService = {
       return { count, subjects }
     } catch (error) {
       throw createError(500, INTERNAL_SERVER_ERROR)
+    }
+  },
+  getCategoryNames: async () => {
+    try {
+      const categoryNames = await Category.find({}, 'name')
+      const count = await Category.countDocuments()
+
+      return { categoryNames, count }
+    } catch (err) {
+      throw createError(404, NOT_FOUND)
     }
   }
 }

--- a/src/services/category.js
+++ b/src/services/category.js
@@ -24,7 +24,7 @@ const categoryService = {
   },
   getCategoryNames: async () => {
     try {
-      const categoryNames = await Category.find({}, 'name')
+      const categoryNames = await Category.find({}, 'name').lean().exec()
       const count = await Category.countDocuments()
 
       return { categoryNames, count }


### PR DESCRIPTION
`/categories/names` endpoint 

I also added `mocks` directory and `categoriesMock.json` file to be able to import it to the DB to test

---
response:
<img width="683" alt="Знімок екрана 2024-08-15 о 11 08 35" src="https://github.com/user-attachments/assets/6fc2fb2b-d27c-45c2-8f9b-36f4f2aeb341">

swagger:
<img width="1258" alt="Знімок екрана 2024-08-15 о 13 18 07" src="https://github.com/user-attachments/assets/57c40bdd-e633-4910-9937-f244857cfe41">

tests:
<img width="654" alt="Знімок екрана 2024-08-15 о 13 22 46" src="https://github.com/user-attachments/assets/03d137fb-2ace-4e82-96ff-413c21e658e5">
