### PR TITLE
added sort,skip,limit functionality for /subjects endpoint

### DIFF
--- a/src/controllers/subject.js
+++ b/src/controllers/subject.js
@@ -1,10 +1,17 @@
 const subjectService = require('~/services/subject')
 const getSortOptions = require('~/utils/getSortOptions')
+const getMatchOptions = require('~/utils/getMatchOptions')
 
 const getSubjects = async (req, res) => {
-  const { sort, skip, limit } = req.query
+  const { sort, skip, limit, name, category } = req.query
+
   const sortOptions = getSortOptions(sort)
-  const subjects = await subjectService.getSubjects(sortOptions, parseInt(skip), parseInt(limit))
+  const match = getMatchOptions({
+    name,
+    category
+  })
+
+  const subjects = await subjectService.getSubjects(match, sortOptions, parseInt(skip), parseInt(limit))
 
   res.status(200).json(subjects)
 }

--- a/src/controllers/subject.js
+++ b/src/controllers/subject.js
@@ -1,7 +1,10 @@
 const subjectService = require('~/services/subject')
+const getSortOptions = require('~/utils/getSortOptions')
 
 const getSubjects = async (req, res) => {
-  const subjects = await subjectService.getSubjects()
+  const { sort, skip, limit } = req.query
+  const sortOptions = getSortOptions(sort)
+  const subjects = await subjectService.getSubjects(sortOptions, parseInt(skip), parseInt(limit))
 
   res.status(200).json(subjects)
 }

--- a/src/services/subject.js
+++ b/src/services/subject.js
@@ -1,13 +1,27 @@
+const mongoose = require('mongoose')
 const Subject = require('~/models/subject')
 const { createError } = require('../utils/errorsHelper')
 const { INTERNAL_SERVER_ERROR, INVALID_ID } = require('~/consts/errors')
 
 const subjectService = {
-  getSubjects: async (sort, skip = 0, limit = 10) => {
+  getSubjects: async (match, sort, skip = 0, limit = 10) => {
     try {
-      const subjects = await Subject.find().sort(sort).skip(skip).limit(limit).lean().exec()
-      const count = await Subject.countDocuments()
-      return { count, subjects }
+      if (match.category) {
+        match.category = mongoose.Types.ObjectId(match.category)
+      }
+      if (match.name) {
+        match.name = { $regex: match.name, $options: 'i' }
+      }
+
+      const total = await Subject.countDocuments(match)
+      if (skip >= total) {
+        return { count: 0, total, subjects: [] }
+      }
+
+      const subjects = await Subject.find(match).sort(sort).skip(skip).limit(limit).lean().exec()
+      const count = subjects.length
+
+      return { count, total, subjects }
     } catch (error) {
       throw createError(500, INTERNAL_SERVER_ERROR)
     }

--- a/src/services/subject.js
+++ b/src/services/subject.js
@@ -3,10 +3,11 @@ const { createError } = require('../utils/errorsHelper')
 const { INTERNAL_SERVER_ERROR, INVALID_ID } = require('~/consts/errors')
 
 const subjectService = {
-  getSubjects: async () => {
+  getSubjects: async (sort, skip = 0, limit = 10) => {
     try {
-      const subjects = await Subject.find().exec()
-      return subjects
+      const subjects = await Subject.find().sort(sort).skip(skip).limit(limit).lean().exec()
+      const count = await Subject.countDocuments()
+      return { count, subjects }
     } catch (error) {
       throw createError(500, INTERNAL_SERVER_ERROR)
     }

--- a/src/test/unit/services/subject.spec.js
+++ b/src/test/unit/services/subject.spec.js
@@ -15,8 +15,12 @@ describe('subjectService', () => {
 
   describe('getSubjects', () => {
     let mockSubjects
+
     beforeEach(() => {
       mockSubjects = [{ name: 'Math' }, { name: 'Science' }]
+
+      Subject.find.mockClear()
+      Subject.countDocuments.mockClear()
 
       Subject.find.mockReturnValue({
         sort: jest.fn().mockReturnThis(),
@@ -30,39 +34,34 @@ describe('subjectService', () => {
     })
 
     it('should return subjects and count when find is successful', async () => {
-      const mockSubjects = [{ name: 'Math' }, { name: 'Science' }]
-      const mockCount = 2
+      const match = {}
+      const sort = {}
+      const skip = 0
+      const limit = 10
 
-      Subject.countDocuments.mockResolvedValue(mockCount)
+      const result = await subjectService.getSubjects(match, sort, skip, limit)
 
-      const result = await subjectService.getSubjects()
-
-      expect(result).toEqual({ count: mockCount, subjects: mockSubjects })
+      expect(result).toEqual({ count: mockSubjects.length, total: mockSubjects.length, subjects: mockSubjects })
       expect(Subject.find).toHaveBeenCalledTimes(1)
-      expect(Subject.find().sort).toHaveBeenCalledTimes(1)
-      expect(Subject.find().skip).toHaveBeenCalledTimes(1)
-      expect(Subject.find().limit).toHaveBeenCalledTimes(1)
+      expect(Subject.find).toHaveBeenCalledWith(match)
+      expect(Subject.find().sort).toHaveBeenCalledWith(sort)
+      expect(Subject.find().skip).toHaveBeenCalledWith(skip)
+      expect(Subject.find().limit).toHaveBeenCalledWith(limit)
       expect(Subject.find().lean).toHaveBeenCalledTimes(1)
       expect(Subject.find().exec).toHaveBeenCalledTimes(1)
       expect(Subject.countDocuments).toHaveBeenCalledTimes(1)
+      expect(Subject.countDocuments).toHaveBeenCalledWith(match)
     })
 
-    it('should throw an error when find fails', async () => {
-      const error = new Error('Database error')
-      Subject.find.mockReturnValue({
-        exec: jest.fn().mockRejectedValue(error)
-      })
-
-      const mockError = createError(500, INTERNAL_SERVER_ERROR)
-      createError.mockReturnValue(mockError)
-
-      await expect(subjectService.getSubjects()).rejects.toEqual(mockError)
-      expect(createError).toHaveBeenCalledWith(500, INTERNAL_SERVER_ERROR)
-    })
-
-    it('should return an empty array and count as 0 when no subjects are found', async () => {
+    it('should not call Subject.find when skip is greater than or equal to count', async () => {
+      const mockCount = 5
       const mockSubjects = []
+      const match = {}
+      const sort = {}
+      const skip = 10
+      const limit = 10
 
+      Subject.countDocuments.mockResolvedValue(mockCount)
       Subject.find.mockReturnValue({
         sort: jest.fn().mockReturnThis(),
         skip: jest.fn().mockReturnThis(),
@@ -71,20 +70,100 @@ describe('subjectService', () => {
         exec: jest.fn().mockResolvedValue(mockSubjects)
       })
 
-      const mockCount = 0
+      const result = await subjectService.getSubjects(match, sort, skip, limit)
+
+      expect(result).toEqual({ count: 0, total: mockCount, subjects: [] })
+
+      expect(Subject.find).not.toHaveBeenCalled()
+
+      expect(Subject.countDocuments).toHaveBeenCalledTimes(1)
+      expect(Subject.countDocuments).toHaveBeenCalledWith(match)
+    })
+
+    it('should handle the case when skip is greater than the total count', async () => {
+      const mockCount = 5
+      const mockSubjects = []
+      const match = {}
+      const sort = {}
+      const skip = 10
+      const limit = 10
 
       Subject.countDocuments.mockResolvedValue(mockCount)
+      Subject.find.mockReturnValue({
+        sort: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        lean: jest.fn().mockReturnThis(),
+        exec: jest.fn().mockResolvedValue(mockSubjects)
+      })
 
-      const result = await subjectService.getSubjects()
+      const result = await subjectService.getSubjects(match, sort, skip, limit)
 
-      expect(result).toEqual({ count: mockCount, subjects: mockSubjects })
-      expect(Subject.find).toHaveBeenCalledTimes(1)
-      expect(Subject.find().sort).toHaveBeenCalledTimes(1)
-      expect(Subject.find().skip).toHaveBeenCalledTimes(1)
-      expect(Subject.find().limit).toHaveBeenCalledTimes(1)
-      expect(Subject.find().lean).toHaveBeenCalledTimes(1)
-      expect(Subject.find().exec).toHaveBeenCalledTimes(1)
+      expect(result).toEqual({ count: 0, total: mockCount, subjects: [] })
       expect(Subject.countDocuments).toHaveBeenCalledTimes(1)
+      expect(Subject.countDocuments).toHaveBeenCalledWith(match)
+      expect(Subject.find).not.toHaveBeenCalled()
+    })
+
+    it('should handle case where match.category is a valid ObjectId', async () => {
+      const match = { category: '507f191e810c19729de860ea' }
+      const sort = {}
+      const skip = 0
+      const limit = 10
+
+      const mockSubjects = [{ name: 'Math' }]
+      Subject.countDocuments.mockResolvedValue(1)
+      Subject.find.mockReturnValue({
+        sort: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        lean: jest.fn().mockReturnThis(),
+        exec: jest.fn().mockResolvedValue(mockSubjects)
+      })
+
+      const result = await subjectService.getSubjects(match, sort, skip, limit)
+
+      expect(result).toEqual({ count: mockSubjects.length, total: 1, subjects: mockSubjects })
+      expect(Subject.countDocuments).toHaveBeenCalledWith(match)
+    })
+
+    it('should handle case where match.name is a regex query', async () => {
+      const match = { name: 'Math' }
+      const sort = {}
+      const skip = 0
+      const limit = 10
+
+      const mockSubjects = [{ name: 'Math' }]
+      Subject.countDocuments.mockResolvedValue(1)
+      Subject.find.mockReturnValue({
+        sort: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        lean: jest.fn().mockReturnThis(),
+        exec: jest.fn().mockResolvedValue(mockSubjects)
+      })
+
+      const result = await subjectService.getSubjects(match, sort, skip, limit)
+
+      expect(result).toEqual({ count: mockSubjects.length, total: 1, subjects: mockSubjects })
+      expect(Subject.countDocuments).toHaveBeenCalledWith(match)
+    })
+
+    it('should handle error and throw a 500 error', async () => {
+      const match = {}
+      const sort = {}
+      const skip = 0
+      const limit = 10
+
+      const error = new Error('Database error')
+      Subject.countDocuments.mockRejectedValueOnce(error)
+
+      const mockError = createError(500, INTERNAL_SERVER_ERROR)
+      createError.mockReturnValue(mockError)
+
+      await expect(subjectService.getSubjects(match, sort, skip, limit)).rejects.toEqual(mockError)
+
+      expect(createError).toHaveBeenCalledWith(500, INTERNAL_SERVER_ERROR)
     })
   })
 

--- a/src/test/unit/services/subject.spec.js
+++ b/src/test/unit/services/subject.spec.js
@@ -14,17 +14,37 @@ describe('subjectService', () => {
   })
 
   describe('getSubjects', () => {
-    it('should return subjects when find is successful', async () => {
-      const mockSubjects = [{ name: 'Math' }, { name: 'Science' }]
+    let mockSubjects
+    beforeEach(() => {
+      mockSubjects = [{ name: 'Math' }, { name: 'Science' }]
+
       Subject.find.mockReturnValue({
+        sort: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        lean: jest.fn().mockReturnThis(),
         exec: jest.fn().mockResolvedValue(mockSubjects)
       })
 
-      const subjects = await subjectService.getSubjects()
+      Subject.countDocuments.mockResolvedValue(mockSubjects.length)
+    })
 
-      expect(subjects).toBe(mockSubjects)
+    it('should return subjects and count when find is successful', async () => {
+      const mockSubjects = [{ name: 'Math' }, { name: 'Science' }]
+      const mockCount = 2
+
+      Subject.countDocuments.mockResolvedValue(mockCount)
+
+      const result = await subjectService.getSubjects()
+
+      expect(result).toEqual({ count: mockCount, subjects: mockSubjects })
       expect(Subject.find).toHaveBeenCalledTimes(1)
+      expect(Subject.find().sort).toHaveBeenCalledTimes(1)
+      expect(Subject.find().skip).toHaveBeenCalledTimes(1)
+      expect(Subject.find().limit).toHaveBeenCalledTimes(1)
+      expect(Subject.find().lean).toHaveBeenCalledTimes(1)
       expect(Subject.find().exec).toHaveBeenCalledTimes(1)
+      expect(Subject.countDocuments).toHaveBeenCalledTimes(1)
     })
 
     it('should throw an error when find fails', async () => {
@@ -40,16 +60,31 @@ describe('subjectService', () => {
       expect(createError).toHaveBeenCalledWith(500, INTERNAL_SERVER_ERROR)
     })
 
-    it('should return an empty array when no subjects are found', async () => {
+    it('should return an empty array and count as 0 when no subjects are found', async () => {
+      const mockSubjects = []
+
       Subject.find.mockReturnValue({
-        exec: jest.fn().mockResolvedValue([])
+        sort: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        lean: jest.fn().mockReturnThis(),
+        exec: jest.fn().mockResolvedValue(mockSubjects)
       })
 
-      const subjects = await subjectService.getSubjects()
+      const mockCount = 0
 
-      expect(subjects).toEqual([])
+      Subject.countDocuments.mockResolvedValue(mockCount)
+
+      const result = await subjectService.getSubjects()
+
+      expect(result).toEqual({ count: mockCount, subjects: mockSubjects })
       expect(Subject.find).toHaveBeenCalledTimes(1)
+      expect(Subject.find().sort).toHaveBeenCalledTimes(1)
+      expect(Subject.find().skip).toHaveBeenCalledTimes(1)
+      expect(Subject.find().limit).toHaveBeenCalledTimes(1)
+      expect(Subject.find().lean).toHaveBeenCalledTimes(1)
       expect(Subject.find().exec).toHaveBeenCalledTimes(1)
+      expect(Subject.countDocuments).toHaveBeenCalledTimes(1)
     })
   })
 


### PR DESCRIPTION
Added filtering by name, category ID.
added count,and total fields to getSubjects response, updated tests.

Retrieved data now looks like:
![image](https://github.com/user-attachments/assets/6bcf9bba-0a03-41d4-869d-57ed24b05dae)

