### PR TITLE
bugfix #91 backend

### DIFF
--- a/src/utils/hashHelper.js
+++ b/src/utils/hashHelper.js
@@ -11,7 +11,8 @@ async function getHash(plainText) {
 }
 
 async function compareHashes(plainText, hash) {
-  return bcrypt.compare(plainText, hash)
+  if (plainText) return bcrypt.compare(plainText, hash)
+  else return false
 }
 
 module.exports = { getHash, compareHashes }

--- a/src/utils/hashHelper.js
+++ b/src/utils/hashHelper.js
@@ -11,7 +11,7 @@ async function getHash(plainText) {
 }
 
 async function compareHashes(plainText, hash) {
-  if (plainText) return bcrypt.compare(plainText, hash)
+  if (plainText && hash) return bcrypt.compare(plainText, hash)
   else return false
 }
 


### PR DESCRIPTION
Pretty straightforward, just a one-line fix.

The essence of the bug is that inside /src/controllers/auth in the googleLogin function we have this row:
  const tokens = await authService.login(ticket.email, null, true)
where the password is null, because we're logging in via google, so there is no password.

But then, inside /src/services/auth there is this line:
  const checkedPassword = (await compareHashes(password, user.password)) || isFromGoogle
where, again, the first argument is null

Finally, inside /src/utils/hashHelper, there is a following function:
  async function compareHashes(plainText, hash) {
    return bcrypt.compare(plainText, hash)
  }
It throws an error if either of arguments is null (in this case, the first argument). The fix is pretty straightforward — to verify that both arguments are present before calling the function:
  async function compareHashes(plainText, hash) {
    if (plainText && hash) return bcrypt.compare(plainText, hash)
    else return false
  }

That's all folks! Please verify that you can use google login again (with the gmail of a user that's already registered), and feel free to approve.